### PR TITLE
Crypto signature validation, Test fixes

### DIFF
--- a/functions/firestore.insecure.rules
+++ b/functions/firestore.insecure.rules
@@ -1,8 +1,0 @@
-rules_version = '2';
-service cloud.firestore {
-    match /databases/{database}/documents {
-        match /{document=**} {
-            allow read, write: if true;
-        }
-    }
-}

--- a/functions/firestore.insecure.rules
+++ b/functions/firestore.insecure.rules
@@ -1,6 +1,6 @@
 rules_version = '2';
 service cloud.firestore {
-  match /databases/{database}/documents {    // lock down the db
+  match /databases/{database}/documents {
     match /{document=**} {
       allow read: if true;
       allow write: if true;

--- a/functions/firestore.insecure.rules
+++ b/functions/firestore.insecure.rules
@@ -1,0 +1,9 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {    // lock down the db
+    match /{document=**} {
+      allow read: if true;
+      allow write: if true;
+    }
+  }
+}

--- a/functions/package.json
+++ b/functions/package.json
@@ -11,7 +11,7 @@
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log",
     "pretest": "tsc --build tsconfig.test.json",
-    "test": "env FIRESTORE_EMULATOR_HOST=localhost:8080 mocha --ui mocha-typescript .mocha"
+    "test": "env FIRESTORE_EMULATOR_HOST=localhost:8080 mocha --ui mocha-typescript .mocha/test"
   },
   "engines": {
     "node": "10"

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -34,8 +34,8 @@ export class Report {
 }
 
 function handleError(response: functions.Response, message: string, code = 400) {
-  var er =  JSON.stringify({
-    code: code,
+  const er =  JSON.stringify({
+    status: code,
     message: message
   });
   console.log(`Error processing report: ${er}`);
@@ -73,7 +73,6 @@ export const submitReport = functions.https.onRequest((request, response) => {
       jsonObject["report_verification_public_key_bytes"],
       "base64"
     )
-//    var result = verifySignature(data.tck, data.memo, data.sig, data.rvk, data.startIndex, data.endIndex, data.memoType)
 
     if(!verifySignature(
       jsonObject["temporary_contact_key_bytes"],

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -5,6 +5,7 @@ import { Field, parse } from "sparkson"
 //registerStringMapper(Buffer, (val: string) => Buffer.from(val, "base64"))
 
 import tcn from "tcn-node"
+import {verifySignature} from "./verify"
 
 // Check for DEBUG_LOGGING
 const DEBUG_LOGGING = process.env.DEBUG_LOGGING || ""
@@ -30,6 +31,16 @@ export class Report {
     @Field("report_verification_public_key_bytes")
     public report_verification_public_key_bytes: string
   ) {}
+}
+
+function handleError(response: functions.Response, message: string, code = 400) {
+  var er =  JSON.stringify({
+    code: code,
+    message: message
+  });
+  console.log(`Error processing report: ${er}`);
+  response.setHeader('content-type', 'application/json; charset=utf-8');
+  response.status(code).send(er);
 }
 
 export const submitReport = functions.https.onRequest((request, response) => {
@@ -62,8 +73,19 @@ export const submitReport = functions.https.onRequest((request, response) => {
       jsonObject["report_verification_public_key_bytes"],
       "base64"
     )
+//    var result = verifySignature(data.tck, data.memo, data.sig, data.rvk, data.startIndex, data.endIndex, data.memoType)
 
-    // validate crypto
+    if(!verifySignature(
+      jsonObject["temporary_contact_key_bytes"],
+      jsonObject["memo_data"],
+      jsonObject["signature_bytes"],
+      jsonObject["report_verification_public_key_bytes"],
+      jsonObject["start_index"],
+      jsonObject["end_index"],
+      jsonObject["memo_type"]
+    )) {
+      throw new Error("Unable to verify signature");
+    }
 
     firestore
       .collection("signed_reports")
@@ -76,11 +98,9 @@ export const submitReport = functions.https.onRequest((request, response) => {
         })
       })
       .catch((error) => {
-        console.log(`Error writing to firestore: ${error}`)
-        response.status(400).send(error)
+        handleError(response, error.message);
       })
   } catch (error) {
-    console.log(`Error processing report: ${error}`)
-    response.status(400).send(error)
+    handleError(response, error.message);
   }
 })

--- a/functions/src/verify.ts
+++ b/functions/src/verify.ts
@@ -1,0 +1,8 @@
+// import tcn from "tcn-node"
+
+
+function bla(): string{
+    return "bla";
+}
+
+export {bla}

--- a/functions/src/verify.ts
+++ b/functions/src/verify.ts
@@ -1,8 +1,50 @@
-// import tcn from "tcn-node"
+const tcn = require("tcn-node");
 
-
-function bla(): string{
-    return "bla";
+function enumMemoTypeOf(memoType: number): string {
+    var res: string;
+    switch(memoType) { 
+        case 0: { 
+           res = 'CoEpiV1'; 
+           break; 
+        } 
+        case 1: { 
+           res = 'CovidWatchV1'; 
+           break; 
+        } 
+        default: { 
+           res = 'Reserved'; 
+           break; 
+        } 
+     };
+     return res;
 }
 
-export {bla}
+function verifySignature(bTck: Buffer, bMemo: Buffer, bSig: Buffer,
+    bRvk: Buffer, startIndex: number, endIndex: number, memoType: number): boolean {
+
+    var report = {
+        rvk: bRvk.toJSON().data,
+        tck_bytes: bTck.toJSON().data,
+        j_1: startIndex,
+        j_2: endIndex,
+        memo_type: enumMemoTypeOf(memoType),
+        memo_data: bMemo.toJSON().data,
+    }
+
+    var sigBytes = bSig.toJSON().data;
+    var sig = {
+        R_bytes: sigBytes.slice(0, 32),
+        s_bytes: sigBytes.slice(32, 64)
+    }
+
+    return tcn.validateReport(
+        {
+            report: report,
+            sig: sig
+        }
+    )
+}
+
+function bla() {return "bla"}
+
+export { verifySignature, bla}

--- a/functions/src/verify.ts
+++ b/functions/src/verify.ts
@@ -1,7 +1,7 @@
 const tcn = require("tcn-node");
 
 function enumMemoTypeOf(memoType: number): string {
-    var res: string;
+    let res: string;
     switch(memoType) { 
         case 0: { 
            res = 'CoEpiV1'; 
@@ -22,7 +22,7 @@ function enumMemoTypeOf(memoType: number): string {
 function verifySignature(bTck: Buffer, bMemo: Buffer, bSig: Buffer,
     bRvk: Buffer, startIndex: number, endIndex: number, memoType: number): boolean {
 
-    var report = {
+    const report = {
         rvk: bRvk.toJSON().data,
         tck_bytes: bTck.toJSON().data,
         j_1: startIndex,
@@ -31,8 +31,8 @@ function verifySignature(bTck: Buffer, bMemo: Buffer, bSig: Buffer,
         memo_data: bMemo.toJSON().data,
     }
 
-    var sigBytes = bSig.toJSON().data;
-    var sig = {
+    const sigBytes = bSig.toJSON().data;
+    const sig = {
         R_bytes: sigBytes.slice(0, 32),
         s_bytes: sigBytes.slice(32, 64)
     }
@@ -46,4 +46,4 @@ function verifySignature(bTck: Buffer, bMemo: Buffer, bSig: Buffer,
 }
 
 
-export { verifySignature }
+export { verifySignature };

--- a/functions/src/verify.ts
+++ b/functions/src/verify.ts
@@ -45,6 +45,5 @@ function verifySignature(bTck: Buffer, bMemo: Buffer, bSig: Buffer,
     )
 }
 
-function bla() {return "bla"}
 
-export { verifySignature, bla}
+export { verifySignature }

--- a/functions/test/test.ts
+++ b/functions/test/test.ts
@@ -1,7 +1,6 @@
 /// <reference path='../node_modules/mocha-typescript/globals.d.ts' />
 
-import { expect } from "chai"
-
+import { assert } from "chai"
 import * as firebase from "@firebase/testing"
 import { setup } from "./utils"
 
@@ -13,7 +12,9 @@ import { setup } from "./utils"
 
 const projectId = "tagstwo-431e3"
 const coverageUrl = `http://${process.env["FIRESTORE_EMULATOR_HOST"]}/emulator/v1/projects/${projectId}:ruleCoverage.html`
-
+const auth = {
+  uid: "covid"
+}
 // /*
 //  * ============
 //  *  Test Cases
@@ -26,54 +27,64 @@ beforeEach(async () => {
 })
 
 after(async () => {
+  // Tear down Firebase apps
   await Promise.all(firebase.apps().map((app) => app.delete()))
   console.log(`View rule coverage information at ${coverageUrl}\n`)
 })
 
-function makeSurveyData() {
-  return {
-    contact_event_key_bytes: "blah",
-    end_index: 21,
-    memo_data: "SGVsbG8sIF",
-    memo_type: 1,
-    report_verification_public_key_bytes: "oxChFfFyTH",
-    signature_bytes: "ETuzy1VioX",
-    start_index: 1,
-    timestamp: firebase.firestore.FieldValue.serverTimestamp(),
-  }
+const mockData = {
+  contact_event_key_bytes: "blah",
+  end_index: 21,
+  memo_data: "SGVsbG8sIF",
+  memo_type: 1,
+  report_verification_public_key_bytes: "oxChFfFyTH",
+  signature_bytes: "ETuzy1VioX",
+  start_index: 1,
+  timestamp: firebase.firestore.FieldValue.serverTimestamp(),
 }
 
 @suite
 export class CovidWatchFirestore {
   @test
-  async "user can read signed_reports"() {
-    const mockData = {
-      signed_reports: {
-        alice: makeSurveyData(),
-      },
-    }
-    const db = await setup(projectId, null, mockData)
-    const report = db.collection("signed_reports").doc("alice")
-    await firebase.assertSucceeds(report.get())
-    await report
-      .get()
-      .then(function (doc: firebase.firestore.DocumentSnapshot) {
-        if (doc.exists) {
-          const data = doc.data()
-          if (data !== undefined && "contact_event_key_bytes" in data) {
-            return expect(data.contact_event_key_bytes).to.equal("blah")
-          }
-        }
-        return expect(false)
+  async "With firestore.rules, user with auth can read and write signed_reports"() {
+    const db = await setup(projectId, auth)
+    const report = db.collection("list").doc("item")
+
+    await firebase.assertSucceeds(
+      report.set({
+        some_random_message: "qwerty",
       })
+    )
+    await firebase.assertSucceeds(report.get())
   }
 
   @test
-  async "should not let anyone write a singed_reports"() {
+  async "Authenticated user should pass sanity check on write and update"() {
+    const db = await setup(projectId, auth)
+    const alice = db.collection("signed_reports").doc("alice");
+
+    await firebase.assertSucceeds(
+      alice.set(mockData)
+    )
+    let aliceData = await firebase.assertSucceeds(alice.get())
+    assert.equal(aliceData.data()["contact_event_key_bytes"], "blah", "Contact event key matched")
+
+    await firebase.assertSucceeds(
+      alice.update({
+        contact_event_key_bytes: "qwerty",
+      })
+    )
+    aliceData = await firebase.assertSucceeds(alice.get())
+    assert.equal(aliceData.data()["contact_event_key_bytes"], "qwerty", "Contact event key updated")
+  }
+
+  @test
+  async "With firestore.rules, user without auth cannot write a signed_reports"() {
     const db = await setup(projectId, null)
-    const survey = db.collection("signed_reports").doc("123")
+    const report = db.collection("signed_reports").doc("alice")
+    await firebase.assertSucceeds(report.get())
     await firebase.assertFails(
-      survey.set({
+      report.set({
         contact_event_key_bytes: "New Data",
       })
     )

--- a/functions/test/utils.ts
+++ b/functions/test/utils.ts
@@ -23,7 +23,20 @@ const setup = async (
   const app = await authedApp(projectId, auth)
   const db = app.firestore()
 
-  // Set Rules
+  // Insecure rules opens write access so we can store admin in /users
+  await firebase.loadFirestoreRules({
+    projectId,
+    rules: fs.readFileSync("./firestore.insecure.rules", "utf8"),
+  })
+
+  if (data) {
+    for (const key in data) {
+      const ref = db.doc(key);
+      await ref.set(data[key]);
+    }
+  }
+
+  // Once admin is stored we can switch to production rules
   await firebase.loadFirestoreRules({
     projectId,
     rules: fs.readFileSync("../firestore.rules", "utf8"),

--- a/functions/test/utils.ts
+++ b/functions/test/utils.ts
@@ -23,30 +23,11 @@ const setup = async (
   const app = await authedApp(projectId, auth)
   const db = app.firestore()
 
-  // Clear rules
-  // Here we load the insecure rules temporarily so we can write to the emulator
-  await firebase.loadFirestoreRules({
-    projectId,
-    rules: fs.readFileSync("firestore.insecure.rules", "utf8"),
-  })
-
-  // Write mock documents before rules
-  if (data) {
-    for (const collection in data) {
-      for (const doc in data[collection]) {
-        const ref = db.collection(collection).doc(doc)
-        await ref.set(data[collection][doc])
-      }
-    }
-  }
-
-  // Apply rules
-  // Restore the correct rules so we can test them
+  // Set Rules
   await firebase.loadFirestoreRules({
     projectId,
     rules: fs.readFileSync("../firestore.rules", "utf8"),
   })
-
   return db
 }
 

--- a/functions/test/verify.test.ts
+++ b/functions/test/verify.test.ts
@@ -1,27 +1,33 @@
 import { expect } from 'chai';
 import 'mocha';
+import {verifySignature} from "../src/verify"
 
-import {bla} from "../src/verify"
-
+const valid = {
+  tck: Buffer.from('PvLGpfQZgGqnoQRtSr0AHd8J5/WdKwaJNLRCkhGlgHU=', "base64"),
+  memo: Buffer.from('SGVsbG8sIFdvcmxkIQ==', "base64"),
+  memoType: 1,
+  startIndex: 1,
+  endIndex:8,
+  sig: Buffer.from('+k7HDsVZPY5Pxcz0cpwVBvDOHrrQ0+AyDVL/MbGkXBYG2WAyoqLaNxFuXiB9rSzkdCesDv1NSSk06hrjx2YABA==', "base64"),
+  rvk: Buffer.from('v78liBBYQrFXqOH6YydUD1aGpXLMgruKATAjFZ0ycLk=', "base64")
+}
 
 @suite
 export class CryptoVerification {
 
   @test
-   "bla is bla"() {
-    const result = bla();
-    expect(result).to.equal('bla');
+  'It should pass for untampered message and signature'() {
+    var data = {...valid}
+    var result = verifySignature(data.tck, data.memo, data.sig, data.rvk, data.startIndex, data.endIndex, data.memoType)
+    expect(result).to.be.true;
+ }
 
-  }
+  @test
+  'It should not pass for tampered message'() {
+    var data = {...valid}
+    data.memoType = 2;
+    var result = verifySignature(data.tck, data.memo, data.sig, data.rvk, data.startIndex, data.endIndex, data.memoType)
+    expect(result).to.be.false;
+ }
 
 }
-
-// describe('Test for crypto verification', () => {
-
-//     it('should return hello world', () => {
-//       const result = bla();
-//       console.log('asdadsa')
-//       expect(result).to.equal('Hello bla!');
-//     });
-  
-//   });

--- a/functions/test/verify.test.ts
+++ b/functions/test/verify.test.ts
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import {bla} from "../src/verify"
+
+
+@suite
+export class CryptoVerification {
+
+  @test
+   "bla is bla"() {
+    const result = bla();
+    expect(result).to.equal('bla');
+
+  }
+
+}
+
+// describe('Test for crypto verification', () => {
+
+//     it('should return hello world', () => {
+//       const result = bla();
+//       console.log('asdadsa')
+//       expect(result).to.equal('Hello bla!');
+//     });
+  
+//   });

--- a/functions/test/verify.test.ts
+++ b/functions/test/verify.test.ts
@@ -23,7 +23,7 @@ export class CryptoVerification {
  }
 
   @test
-  'It should not pass for tampered message'() {
+  'It should not pass for tampered message or signature'() {
     var data = {...valid}
     data.memoType = 2;
     var result = verifySignature(data.tck, data.memo, data.sig, data.rvk, data.startIndex, data.endIndex, data.memoType)


### PR DESCRIPTION
Added digital signature validation based on tcn-node exposed validation method. (https://github.com/covid19risk/tcn-node/issues/5)
- added the implementation and its unit test
- adjusted response to allow custom error message (previously pretty error came from spakson lib)
- fixed Firebase rules that gave non-auth user write access #5 