### PR TITLE
Make handlers simpler, factoring out setup and error handling

### DIFF
--- a/functions/challenge.go
+++ b/functions/challenge.go
@@ -2,28 +2,22 @@ package functions
 
 import (
 	"encoding/json"
-	"net/http"
 
 	"functions/internal/pow"
 	"functions/internal/util"
 )
 
 // ChallengeHandler is a handler for the /challenge endpoint.
-func ChallengeHandler(w http.ResponseWriter, r *http.Request) {
-	ctx, err := util.NewContext(w, r)
-	if err != nil {
-		return
-	}
-
-	if err := util.ValidateRequestMethod(&ctx, "GET", ""); err != nil {
-		ctx.WriteStatusError(err)
-		return
+func ChallengeHandler(ctx *util.Context) util.StatusError {
+	if err := util.ValidateRequestMethod(ctx, "GET", ""); err != nil {
+		return err
 	}
 
 	c, err := pow.GenerateChallenge(ctx)
 	if err != nil {
-		ctx.WriteStatusError(util.NewInternalServerError(err))
-		return
+		return util.NewInternalServerError(err)
 	}
-	json.NewEncoder(w).Encode(c)
+	json.NewEncoder(ctx.HTTPResponseWriter()).Encode(c)
+
+	return nil
 }

--- a/functions/cmd/main.go
+++ b/functions/cmd/main.go
@@ -1,17 +1,20 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 
 	"functions"
+	"functions/internal/util"
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/funcframework"
 )
 
 func main() {
-	funcframework.RegisterHTTPFunction("/challenge", functions.ChallengeHandler)
+	funcframework.RegisterHTTPFunction("/challenge", makeHTTPHandler(functions.ChallengeHandler))
 	// Use PORT environment variable, or default to 8080.
 	port := "8080"
 	if envPort := os.Getenv("PORT"); envPort != "" {
@@ -22,4 +25,31 @@ func main() {
 	if err := funcframework.Start(port); err != nil {
 		log.Fatalf("funcframework.Start: %v\n", err)
 	}
+}
+
+func makeHTTPHandler(handler func(ctx *util.Context) util.StatusError) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, err := util.NewContext(w, r)
+		if err != nil {
+			writeStatusError(w, r, err)
+			return
+		}
+
+		if err := handler(&ctx); err != nil {
+			writeStatusError(w, r, err)
+		}
+	}
+}
+
+func writeStatusError(w http.ResponseWriter, r *http.Request, err util.StatusError) {
+	type response struct {
+		Message string `json:"message"`
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(err.HTTPStatusCode())
+	json.NewEncoder(w).Encode(response{Message: err.Message()})
+
+	log.Printf("[%v %v %v]: responding with error code %v and message \"%v\"",
+		r.RemoteAddr, r.Method, r.URL, err.HTTPStatusCode(), err.Message())
 }

--- a/functions/internal/pow/pow.go
+++ b/functions/internal/pow/pow.go
@@ -147,7 +147,7 @@ type challengeDoc struct {
 }
 
 // GenerateChallenge generates a new challenge and stores it in the database.
-func GenerateChallenge(ctx util.Context) (*Challenge, error) {
+func GenerateChallenge(ctx *util.Context) (*Challenge, error) {
 	c := generateChallenge(defaultWorkFactor)
 
 	doc := challengeDoc{Expiration: time.Now().Add(expirationPeriod)}


### PR DESCRIPTION
Change the signature of handlers so that they take a `*util.Context` and return a `util.StatusError`. The `main` package is responsible for providing a handler with the original signature - taking both an `http.ResponseWriter` and an `*http.Request` - and is responsible for constructing a `*util.Context` and handling any errors. Once we have more handlers, this will save us a lot of boilerplate, and will also reduce the possibility for mistakes (e.g., omitting error handling in certain paths).