### PR TITLE
Updating GitHub Actions to only run our deployment target during pr's

### DIFF
--- a/.github/workflows/pull_master.yml
+++ b/.github/workflows/pull_master.yml
@@ -1,0 +1,25 @@
+# To ensure the code works on other platforms than the 1.13 linux target we run a full
+# matrix of targets only when merging into master
+name: CI master
+on:
+  push:
+    branches:
+      - "master"
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.13.x, 1.14.x]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Test
+        run: cd functions && go test ./...

--- a/.github/workflows/push_dev.yml
+++ b/.github/workflows/push_dev.yml
@@ -1,11 +1,14 @@
-name: CI
-on: [push, pull_request]
+# To reduce noise and wasted github actions we only run the 1.13 linux target on
+# pull requests
+name: CI dev
+on: [pull_request]
+
 jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x]
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        go-version: [1.13.x]
+        platform: [ubuntu-latest]
       fail-fast: false
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
- Full matrix of tests has been moved to merging into master only

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/covid19risk/covidwatch-cloud-functions/51)
<!-- Reviewable:end -->
